### PR TITLE
fix(codecov): jest configration fix

### DIFF
--- a/test/config.json
+++ b/test/config.json
@@ -7,6 +7,6 @@
         "statements": 100
       }
     },
-    "coverageDirectory": "./coverage/",
+    "coverageDirectory": "../coverage/",
     "collectCoverage": true
 }


### PR DESCRIPTION
## issues 
closes #8 jest configration was mistakenly pointing to test folder for the extraction of the
coverage folder, while the right folder should be root.